### PR TITLE
Add the option to ask interactively for the username.

### DIFF
--- a/jvpn.ini
+++ b/jvpn.ini
@@ -8,8 +8,12 @@ port=443
 # if not set url=url_default
 url=url_default
 #
-# vpn username
-username=jsmith
+# it is possible to setup a vpn username in the configuration file or ask it interactively
+# To prompt for the username every time, use:
+# username=interactive
+# To setup a username in the configuration file:
+# username=myusername
+username=interactive
 #
 # realm - could be taken from web login form
 realm=Very Secure ID


### PR DESCRIPTION
Add the option to ask interactively for the username to make it easier to
share a config file between multiple users.

The read_password function is changed to read_input and supports reading the
pressed keys and displaying them (normal input) or displaying "*" (password).

Signed-off-by: Gert Hulselmans hulselmansgert@gmail.com
