### PR TITLE
Bypass Post Sign-In Notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ META.yml
 MYMETA.yml
 nytprof.out
 pm_to_blib
+libncui.so
+ncLinuxApp.jar
+ncsvc
+tncc.jar
+compile.log
+ncui


### PR DESCRIPTION
Our company utilizes the Post Sign-In Notification from time to time
to inform us of updates/bugs/etc.  When that's used the scripting would
not be able to finish getting the DSID.  This commit adds code to check
if the Post Sign-In page comes up instead of the expected page.  If so
it posts to the correct page with the necessary form values to get
to the expected page and finish getting the DSID value.