### PR TITLE
Do not remove last line with stats when connection is terminated because...

### DIFF
--- a/jvpn.pl
+++ b/jvpn.pl
@@ -550,18 +550,18 @@ if($mode eq "ncsvc") {
 	while ( 1 ) {
 		#stat query
 		$data="\0\0\0\0\0\0\0\x69\x01\0\0\0\x01\0\0\0\0\0\0\0";
-		print "\r                                                              \r";
 		hdump($data) if $debug;
 		print $socket "$data";
 		$socket->recv($data,2048);
 		if(!length($data) || !$socket->connected()) {
-		    print "No response from ncsvc, closing connection\n";
+		    print "\nNo response from ncsvc, closing connection\n";
 		    INT_handler();
 		}
 		hdump($data) if $debug;
 		my $now = time - $start_t;
 		# printing RX/TX. This packet also contains encription type,
 		# compression and transport info, but length seems to be variable
+		print "\r                                                              \r";
 		printf("Duration: %02d:%02d:%02d  Sent: %s\tReceived: %s", 
 			int($now / 3600), int(($now % 3600) / 60), int($now % 60),
 			format_bytes(unpack('x[78]N',$data)), format_bytes(unpack('x[68]N',$data)));


### PR DESCRIPTION
... of no response from ncsvc.

Example:

```
alex@debian:~/jvpn$ ./jvpn.pl 
Enter PIN+password: *********
Transfer went ok
Got DSID
Certificate fingerprint:  [****************************]
TCP Connection to ncsvc process established.
Sending handshake #1 packet...  [done]
Sending handshake #2 packet...  [done]
Sending configuration packet... [done]
Running user-defined script
IP: 10.12.134.203 Gateway: 10.200.200.200
DNS1: 10.12.1.61  DNS2: 10.12.1.101
Connected to ************, press CTRL+C to exit
Duration: 00:00:30  Sent: 0.00 B        Received: 0.00 B      <-- this line is missing
No response from ncsvc, closing connection
Logging out...
Killing ncsvc...
restoring resolv.conf
Running user-defined script
Exiting
```

BTW, for `ncui` version everything is OK with stats on connection lost, the `\r` is printed just before stats refresh, as in this PR.

P.S. thank you for a great script!
