### PR TITLE
Correct reference to password prompt subroutine

### DIFF
--- a/jvpn.pl
+++ b/jvpn.pl
@@ -182,7 +182,7 @@ if ($res->is_success) {
 			print $1;
 			print "\n";
 			print "Enter challenge response: ";
-			$password=read_password();
+			$password=read_input("password");
 			print "\n";
 		}
 		# if password was specified in plaintext we should not use it 
@@ -191,7 +191,7 @@ if ($res->is_success) {
 			print "To continue, wait for the token code to change and ".
 			"then enter the new pin and code.\n";
 			print "Enter PIN+password: ";
-			$password=read_password();
+			$password=read_input("password");
 			print "\n";
 		}
 		elsif ($cfgpass =~ /^helper:(.+)/) {


### PR DESCRIPTION
Some VPNs ask for a second token code. Correct the call to
read_password() in these cases to read_input("password").

See 2065462 where the subroutine was renamed.

The error message is:
Undefined subroutine &main::read_password called at ./jvpn.pl line 194.
